### PR TITLE
Add check-coverage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,16 +24,10 @@ repos:
   # Language syntax/formatting
   - id: check-yaml
     stages: [commit]
-- repo: local
+- repo: https://github.com/mattlqx/pre-commit-ruby
+  rev: v1.3.3
   hooks:
   - id: rubocop
-    name: Check Ruby style with rubocop
-    description: Enforce Ruby style guide with rubocop
-    entry: bin/rubocop-wrapper.sh
-    language: script
-    types: ['ruby']
-    stages: [commit]
-    verbose: true
 - repo: https://github.com/mattlqx/pre-commit-sign
   rev: v1.1.1
   hooks:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -30,3 +30,18 @@
   args:
   - test
   - rules
+
+- id: check-coverage
+  stages: [commit]
+  name: Coverage of unit test prometheus rule files
+  description: Coverage of unit test prometheus rule files
+  language: script
+  entry: bin/prom_coverage.rb
+  pass_filenames: false
+  always_run: true
+  args:
+    - prometheus/alerts
+    - prometheus/unit-tests
+    - '80'
+    - unused_alerts.yml
+    - whytest.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'rake', '~> 13.0'
+
+gem 'rspec', '~> 3.0'
+
+gem 'rubocop', '~> 0.80'

--- a/README.md
+++ b/README.md
@@ -44,3 +44,108 @@ In the example provided, we are setting this to always run as rule files could b
           (?x)^(
             unit_test_directory/.*\.yml
           )$
+
+
+
+### prom_coverage
+prom_coverage is a ruby script to be run by pre-commit to ensure prometheus alerts are unit tested. "Are unit tested" is defined as at least 1 test with the same name as the alert. There is an option to ignore alert filenames, this is currently being used to ignore rules that are going away in the future.
+#### Usage
+```
+- repo: https://github.com/fortman/pre-commit-prometheus
+      rev: v1.3.0
+      hooks:
+      - id: check-coverage
+        entry: bin/prom_coverage.rb
+        pass_filenames: false
+        args:
+          - prometheus/alerts/
+          - prometheus/unit-tests/
+          - '80'
+          - rabbitmq.yml
+          - redis.yml
+```
+
+**Script uses positional arguments only.**
+
+| Pos | Description | Example Value |
+| --- | --- | -- |
+| 1 | rules directory | `prometheus/alerts/` |
+| 2 | unit tests directory | `prometheus/unit-tests/` |
+| 3 | percent coverage accepted | `'80'` |
+| 4* | rule filename to ignore | `rabbitmq.yml redis.yml postgres.yml` |
+
+Example successful execution output.
+```
+ruby bin/prom_coverage.rb \
+prometheus/alerts/ \
+prometheus/unit-tests \
+65 \
+rabbitmq.yml \
+redis.yml \
+postgres.yml \
+
+"skiplist: [\"rabbitmq.yml\", \"redis.yml\", \"postgres.yml\"]"
+"skipped: 14"
+"coverage: 79.0%"
+"accepted: 65%"
+"---Missing---"
+"tier2-support.yml - NovaStudentInvalidID_tier2"
+"postgresql.yml - PostgreSQL_Service_Down"
+"postgresql.yml - PostgreSQL_Maximum_Connections"
+"postgresql.yml - PostgreSQL_High_Connections"
+"postgresql.yml - PostgreSQL_Replication_Slot_Inactive"
+"postgresql.yml - PostgreSQL_XID_Wraparound_Warning"
+"postgresql.yml - PostgreSQL_XID_Wraparound_Critical"
+"postgresql.yml - PostgreSQL_Force_Freeze"
+"postgresql.yml - PostgreSQL_Replication_Lag"
+"stparser-assets.yml - StparserDDXML1TemplatesError"
+"stparser-assets.yml - StparserDDXML2TemplatesError"
+"stparser-assets.yml - StparserResourcesError"
+"vmware.yml - Host_Warn_Cpu_Usage"
+"vmware.yml - Host_Crit_Cpu_Usage"
+"vmware.yml - Host_Warn_Mem_Usage"
+"vmware.yml - Host_Crit_Mem_Usage"
+"vmware.yml - Predict_Disk_Space_Warn"
+"vmware.yml - Predict_Disk_Space_Crit"
+"networking.yml - HighCpuUtilizationManagement"
+"networking.yml - HighCpuUtilizationDataPlane"
+"networking.yml - DeviceStatusUnkownOrIssue"
+```
+Example fail execution output.
+```
+% ruby bin/prom_coverage.rb \
+> prometheus/alerts/ \
+> prometheus/unit-tests \
+> '85' \
+> rabbitmq.yml \
+> redis.yml \
+> postgres.yml \
+>
+"skiplist: [\"rabbitmq.yml\", \"redis.yml\", \"postgres.yml\"]"
+"skipped: 14"
+"coverage: 79.0%"
+"accepted: 85%"
+"---Missing---"
+"tier2-support.yml - NovaStudentInvalidID_tier2"
+"postgresql.yml - PostgreSQL_Service_Down"
+"postgresql.yml - PostgreSQL_Maximum_Connections"
+"postgresql.yml - PostgreSQL_High_Connections"
+"postgresql.yml - PostgreSQL_Replication_Slot_Inactive"
+"postgresql.yml - PostgreSQL_XID_Wraparound_Warning"
+"postgresql.yml - PostgreSQL_XID_Wraparound_Critical"
+"postgresql.yml - PostgreSQL_Force_Freeze"
+"postgresql.yml - PostgreSQL_Replication_Lag"
+"stparser-assets.yml - StparserDDXML1TemplatesError"
+"stparser-assets.yml - StparserDDXML2TemplatesError"
+"stparser-assets.yml - StparserResourcesError"
+"vmware.yml - Host_Warn_Cpu_Usage"
+"vmware.yml - Host_Crit_Cpu_Usage"
+"vmware.yml - Host_Warn_Mem_Usage"
+"vmware.yml - Host_Crit_Mem_Usage"
+"vmware.yml - Predict_Disk_Space_Warn"
+"vmware.yml - Predict_Disk_Space_Crit"
+"networking.yml - HighCpuUtilizationManagement"
+"networking.yml - HighCpuUtilizationDataPlane"
+"networking.yml - DeviceStatusUnkownOrIssue"
+promcheck.rb:127:in `<main>': accepted 85 > actual coverage 79.0 (RuntimeError)
+```

--- a/bin/prom_coverage.rb
+++ b/bin/prom_coverage.rb
@@ -1,0 +1,128 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'yaml'
+
+# example values
+# rules_dir = '../chef-cookbooks/cookbooks/pprometheus_v2/files/default/alerts'
+# tests_dir = '../chef-cookbooks/cookbooks/pprometheus_v2/files/default/unit-tests'
+# accepted = 80
+# exclude = ['rabbitmq.yml', 'redis.yml', 'postgresql.yml',
+#            'win_systems.yml', 'vmware.yml', 'networking.yml',
+#            'stparser-assets.yml']
+
+# relative path, relative path, number (percent), alert sources to ignore
+rules_dir, tests_dir, accepted, *exclude = ARGV
+
+def get_yaml_files(dir)
+  Dir.entries(dir).select do |f|
+    /.*?\.y(?a)ml/ =~ f
+  end
+end
+
+def load_file(directory, filename)
+  path = File.join(directory, filename)
+  data = File.open(path).read
+  YAML.safe_load(data)
+end
+
+# rubocop:disable Metrics/MethodLength
+def get_rules(yml)
+  out = []
+  yml['groups'].each do |group|
+    group['rules'].each do |rule|
+      begin
+        out.push(rule['alert'])
+      rescue StandardError
+        p 'didnt have rule["alert"] name'
+      end
+    end
+  end
+  out
+end
+# rubocop:enable Metrics/MethodLength
+
+def get_all_rules(dir)
+  yaml_files = get_yaml_files(dir)
+  out = []
+  yaml_files.each do |f|
+    # out.push(load_file(dir, f))
+    yml = load_file(dir, f)
+    rules = get_rules(yml)
+    rules.each do |r|
+      out.push({ source: f, rule: r }) if r
+    end
+  end
+  out
+end
+
+def get_tests(yml)
+  out = []
+  yml['tests'].each do |test|
+    test['alert_rule_test'].each do |rule|
+      out.push(rule['alertname'])
+    end
+  end
+  out
+end
+
+def get_all_tests(dir)
+  yaml_files = get_yaml_files(dir)
+  out = []
+  yaml_files.each do |f|
+    # out.push(load_file(dir, f))
+    yml = load_file(dir, f)
+    rules = get_tests(yml)
+    rules.each do |r|
+      out.push({ source: f, rule: r })
+    end
+  end
+  out
+end
+
+rules = get_all_rules(rules_dir)
+qrules = rules.uniq
+tests = get_all_tests(tests_dir)
+qtests = tests.uniq
+
+qtests_names = []
+qtests.each do |e|
+  qtests_names.push(e[:rule])
+end
+
+missing_tests = qrules - qtests
+
+skipped = []
+final_missing = []
+missing_tests.each do |mt|
+  if qtests_names.include? mt[:rule]
+    skipped.push(mt)
+  else
+    final_missing.push(mt)
+  end
+end
+
+missing = []
+final_missing.each do |t|
+  if exclude.include? t[:source]
+    skipped.push(t)
+  else
+    missing.push(t)
+  end
+end
+
+coverage = ((rules.length - missing.length) / rules.length.to_f).round(2) * 100
+
+# ----------------------------
+p "skiplist: #{exclude}"
+p "skipped: #{skipped.length}"
+p "coverage: #{coverage}%"
+p "accepted: #{accepted}%"
+p '---Missing Tests---'
+
+missing.each do |m|
+  p "#{m[:source]} - #{m[:rule]}"
+end
+
+exit(0) if coverage >= accepted.to_f
+raise "accepted #{accepted} > actual coverage #{coverage}"


### PR DESCRIPTION
Add `check-coverage` to run simple code coverage scan. Requires positional arguments.
Add remote rubocop pre-commit since local one isn't here.
Add Gemfile so that pre-commit recognizes as a gem.
Add documentation.

Success
```
% pre-commit run --all-files check-coverage
Coverage of unit test prometheus rule files..............................Passed
```

Failure
```
% pre-commit run --all-files check-coverage
Coverage of unit test prometheus rule files..............................Failed
- hook id: check-coverage
- exit code: 1

"skiplist: [\"rabbitmq.yml\", \"redis.yml\", \"postgres.yml\", \"win_systems.yml\", \"vmware.yml\", \"networking.yml\", \"stparser-assets.yml\"]"
"skipped: 26"
"coverage: 91.0%"
"accepted: 95%"
"---Missing Tests---"
"tier2-support.yml - NovaStudentInvalidID_tier2"
"postgresql.yml - PostgreSQL_Service_Down"
"postgresql.yml - PostgreSQL_Maximum_Connections"
"postgresql.yml - PostgreSQL_High_Connections"
"postgresql.yml - PostgreSQL_Replication_Slot_Inactive"
"postgresql.yml - PostgreSQL_XID_Wraparound_Warning"
"postgresql.yml - PostgreSQL_XID_Wraparound_Critical"
"postgresql.yml - PostgreSQL_Force_Freeze"
"postgresql.yml - PostgreSQL_Replication_Lag"
Traceback (most recent call last):
/Users/sixgen/.cache/pre-commit/repoq4x2ndjj/bin/prom_coverage.rb:128:in `<main>': accepted 95 > actual coverage 91.0 (RuntimeError)
```

Precommit-Verified: aee447ff25605e093b97e0f71b58375edea13ccd8fb60d155c82df2ddd8b540f