### PR TITLE
Add amtool as pre-commit hook for alertmanager configuration checks 

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -30,3 +30,13 @@
   args:
   - test
   - rules
+
+- id: check-alertmanager-config
+  stages: [commit]
+  name: Check alertmanager config files
+  description: Check alertmanager config files
+  language: docker_image
+  entry: --entrypoint /bin/amtool prom/alertmanager:latest
+  files: ^$
+  args:
+  - check-config  

--- a/README.md
+++ b/README.md
@@ -44,3 +44,15 @@ In the example provided, we are setting this to always run as rule files could b
           (?x)^(
             unit_test_directory/.*\.yml
           )$
+
+To lint Alertmanager Config files, use the `alertmanager-config` hook.  Make sure to filter files passed to hook by defining the `files` section.  Note: the `entry` option below is optional and will default to the latest alertmanager version.  It is shown just as an example of pinning to a specific alertmanager version.
+
+    - repo: https://github.com/fortman/pre-commit-prometheus
+      rev: v1.1.1
+      hooks:
+      - id: check-alertmanager-config
+        entry: --entrypoint /bin/amtool prom/alertmanager:v0.21.0
+        files: >
+          (?x)^(
+            config_directory/.*\.yml
+          )$          


### PR DESCRIPTION
**Description:**
- Adds `amtool check-config` as a pre-commit hook to verify alert manager configuration files.